### PR TITLE
Allows to specify selected secret names to retrieve.

### DIFF
--- a/cmd/print.go
+++ b/cmd/print.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/apex/log"
 	"github.com/spf13/cobra"
@@ -17,8 +18,16 @@ var printCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		vaultName := viper.GetString("vault-name")
-		log.Debugf("getting secrets for %s", vaultName)
-		secrets, err := lib.GetSecrets(vaultName)
+		var secretNames []string
+		if err := viper.UnmarshalKey("secret-names", &secretNames); err != nil {
+			log.WithError(err).Fatal("can't unmarshal secret names")
+		}
+		if len(secretNames) > 0 {
+			log.Debugf("getting secrets \"%s\" for %s", strings.Join(secretNames, ", "), vaultName)
+		} else {
+			log.Debugf("getting all secrets for %s", vaultName)
+		}
+		secrets, err := lib.GetSecrets(vaultName, secretNames...)
 		if err != nil {
 			log.WithError(err).Fatal("can't get secrets")
 		}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,10 +35,12 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVarP(&config, "config", "c", "", "TODO: Path to the config file (optional). Allows to set transformations")
 	rootCmd.PersistentFlags().StringP("vault-name", "n", "", "KeyVault name")
+	rootCmd.PersistentFlags().StringSliceP("secret-name", "s", []string{}, "Secret names to pull. If a name starts with json:, i.e. json:secret1, they are treated as JSON objects. If not set akv-entrypoint will List all secrets and read them all. Can be specified multiple times. If set via env var AKV_ENTRYPOINT_SECRET_NAMES, multiple values should be separated by a comma.")
 	rootCmd.PersistentFlags().BoolP("debug", "d", false, "Turn on debug logging")
 
 	viper.BindPFlag("debug", rootCmd.PersistentFlags().Lookup("debug"))
 	viper.BindPFlag("vault-name", rootCmd.PersistentFlags().Lookup("vault-name"))
+	viper.BindPFlag("secret-names", rootCmd.PersistentFlags().Lookup("secret-name"))
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 
 	"github.com/apex/log"
@@ -18,8 +19,16 @@ var runCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 
 		vaultName := viper.GetString("vault-name")
-		log.Debugf("getting secrets for %s", vaultName)
-		secrets, err := lib.GetSecrets(vaultName)
+		var secretNames []string
+		if err := viper.UnmarshalKey("secret-names", &secretNames); err != nil {
+			log.WithError(err).Fatal("can't unmarshal secret names")
+		}
+		if len(secretNames) > 0 {
+			log.Debugf("getting secrets \"%s\" for %s", strings.Join(secretNames, ", "), vaultName)
+		} else {
+			log.Debugf("getting all secrets for %s", vaultName)
+		}
+		secrets, err := lib.GetSecrets(vaultName, secretNames...)
 		if err != nil {
 			log.WithError(err).Fatal("can't get secrets")
 		}

--- a/lib/keyvault.go
+++ b/lib/keyvault.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	"github.com/apex/log"
 	"github.com/imdario/mergo"
@@ -12,7 +13,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/keyvault/azsecrets"
 )
 
-func GetSecrets(keyVaultName string) (map[string]string, error) {
+func GetSecrets(keyVaultName string, secretNames ...string) (map[string]string, error) {
 	ctx := log.WithField("vault_name", keyVaultName)
 
 	keyVaultURL := fmt.Sprintf("https://%s.vault.azure.net/", keyVaultName)
@@ -30,40 +31,73 @@ func GetSecrets(keyVaultName string) (map[string]string, error) {
 
 	secrets := make(map[string]string)
 
-	//List secrets
-	pager := client.ListPropertiesOfSecrets(nil)
-	for pager.More() {
-		page, err := pager.NextPage(context.TODO())
-		if err != nil {
-			return nil, fmt.Errorf("error while listing secrets: %s", err)
-		}
-
-		for _, v := range page.Secrets {
-			secret, err := client.GetSecret(context.TODO(), *v.Name, nil)
+	if len(secretNames) > 0 {
+		// pick specific secrets
+		for _, secretName := range secretNames {
+			var isJSON bool
+			if strings.HasPrefix(secretName, "json:") {
+				secretName = strings.TrimPrefix(secretName, "json:")
+				isJSON = true
+			}
+			keyValue, err := getSecret(client, secretName, isJSON)
 			if err != nil {
-				return nil, fmt.Errorf("can't retrieve '%s' from '%s': %s", *v.Name, keyVaultName, err)
+				return nil, fmt.Errorf("can't retrieve secrets from '%s': %s", keyVaultName, err)
 			}
-
-			keyValue := make(map[string]string)
-			// if the content-type is application/json we'll get it as an object.
-			// otherwise it'll be taken as a key->value where key is the secret name
-			if contentType := v.ContentType; contentType != nil && *contentType == "application/json" {
-				log.Debugf("JSON Secret Name: %s\tSecret Tags: %v", *v.ID, v.Tags)
-				if err := json.Unmarshal([]byte(*secret.Value), &keyValue); err != nil {
-					return nil, fmt.Errorf("Can't unmarshal json: %s", err)
-				}
-			} else {
-				log.Debugf("PLAIN Secret Name: %s\tSecret Tags: %v", *v.ID, v.Tags)
-				keyValue[*v.Name] = *secret.Value
-			}
-
 			// merge the resulting map with the collector one
 			err = mergo.Merge(&secrets, &keyValue, mergo.WithOverride)
 			if err != nil {
 				return nil, fmt.Errorf("Can't merge maps: %s", err)
 			}
 		}
+
+	} else {
+		//List secrets
+		pager := client.ListPropertiesOfSecrets(nil)
+		for pager.More() {
+			page, err := pager.NextPage(context.TODO())
+			if err != nil {
+				return nil, fmt.Errorf("error while listing secrets: %s", err)
+			}
+
+			for _, v := range page.Secrets {
+				var isJSON bool
+				if v.ContentType != nil && *v.ContentType == "application/json" {
+					isJSON = true
+				}
+				keyValue, err := getSecret(client, *v.Name, isJSON)
+				if err != nil {
+					return nil, fmt.Errorf("can't retrieve secrets from '%s': %s", keyVaultName, err)
+				}
+
+				// merge the resulting map with the collector one
+				err = mergo.Merge(&secrets, &keyValue, mergo.WithOverride)
+				if err != nil {
+					return nil, fmt.Errorf("Can't merge maps: %s", err)
+				}
+			}
+		}
 	}
 
 	return secrets, nil
+}
+func getSecret(client *azsecrets.Client, secretName string, isJSON bool) (map[string]string, error) {
+	secret, err := client.GetSecret(context.TODO(), secretName, nil)
+	if err != nil {
+		return nil, fmt.Errorf("can't retrieve '%s': %s", secretName, err)
+	}
+
+	keyValue := make(map[string]string)
+	// if the content-type is application/json we'll get it as an object.
+	// otherwise it'll be taken as a key->value where key is the secret name
+	if isJSON {
+		log.Debugf("JSON Secret Name: %s", secretName)
+		if err := json.Unmarshal([]byte(*secret.Value), &keyValue); err != nil {
+			return nil, fmt.Errorf("Can't unmarshal json: %s", err)
+		}
+	} else {
+		log.Debugf("PLAIN Secret Name: %s", secretName)
+		keyValue[secretName] = *secret.Value
+	}
+
+	return keyValue, nil
 }


### PR DESCRIPTION
Can be set with -s flag or as a AKV_ENTRYPOINT_SECRET_NAMES environment
variable. Multiple secrets are separated by comma.

If a secret name is prefixed with "json:", it'll be treated as
a JSON object and unwrapped into the env vars as is.
